### PR TITLE
feature/create-application-layer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,14 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+tokio = { version = "1.43", features = ["test-util", "macros"] }
+tokio-macros = "2.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bech32 = "0.11"
 base64 = "0.22"
 rand = "0.8"
 chrono = "0.4.39"
+async-trait = "0.1"
+thiserror = "2.0"
+anyhow = "1.0"

--- a/src/application/common/exceptions.rs
+++ b/src/application/common/exceptions.rs
@@ -1,0 +1,41 @@
+use std::collections::HashMap;
+use thiserror::Error;
+
+
+fn format_error_map(errors: &HashMap<String, String>) -> String {
+    let mut entries = errors.iter().collect::<Vec<_>>();
+    entries.sort_by(|a, b| a.0.cmp(b.0));
+
+    let formatted_entries: Vec<String> = entries
+        .iter()
+        .map(|(key, value)| format!("{}: {}", key, value))
+        .collect();
+
+    format!("[{}]", formatted_entries.join(", "))
+}
+
+#[derive(Debug, Error)]
+pub enum ApplicationError {
+    #[error("Invalid data: {}", format_error_map(.0))]
+    InvalidData(HashMap<String, String>),
+    #[error("Not found: {0}")]
+    NotFound(String),
+    #[error(transparent)]
+    Other(#[from] anyhow::Error)
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_error_map() {
+        let mut map = HashMap::new();
+        map.insert("field1".to_string(), "error1".to_string());
+        map.insert("field2".to_string(), "error2".to_string());
+
+        let formatted = format_error_map(&map);
+        assert_eq!(formatted, "[field1: error1, field2: error2]");
+    }
+}

--- a/src/application/common/hasher.rs
+++ b/src/application/common/hasher.rs
@@ -1,0 +1,8 @@
+use async_trait::async_trait;
+
+
+#[async_trait]
+pub trait Hasher {
+    async fn hash(&self, value: &str) -> [u8];
+    async fn verify(&self, value: &str, hash: &[u8]) -> bool;
+}

--- a/src/application/common/interactor.rs
+++ b/src/application/common/interactor.rs
@@ -1,0 +1,7 @@
+use async_trait::async_trait;
+use super::exceptions::ApplicationError;
+
+#[async_trait]
+pub trait Interactor<I = (), O = ()> {
+    async fn execute(&self, data: I) -> Result<O, ApplicationError>;
+}

--- a/src/application/common/mod.rs
+++ b/src/application/common/mod.rs
@@ -1,0 +1,3 @@
+pub mod interactor;
+pub mod hasher;
+pub mod exceptions;

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -1,0 +1,2 @@
+pub mod common;
+pub mod transaction;

--- a/src/application/transaction/create.rs
+++ b/src/application/transaction/create.rs
@@ -1,0 +1,45 @@
+use async_trait::async_trait;
+use crate::application::common::exceptions::ApplicationError;
+use crate::application::common::interactor::Interactor;
+use crate::domain::models::transaction::Transaction;
+
+pub struct CreateTransactionResult {
+
+}
+
+pub struct CreateTransaction {}
+
+#[async_trait]
+impl Interactor<Transaction, CreateTransactionResult> for CreateTransaction {
+    async fn execute(&self, data: Transaction) -> Result<CreateTransactionResult, ApplicationError> {
+        Ok(CreateTransactionResult {})
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use crate::domain::models::address::Address;
+    use crate::domain::models::hash::Hash;
+    use crate::domain::models::signature::Signature;
+    use crate::domain::models::token::Token;
+    use super::*;
+    use crate::domain::models::transaction::Transaction;
+
+    #[tokio::test]
+    async fn test_create_transaction() {
+        let interactor = CreateTransaction {};
+        let transaction = Transaction {
+            hash: Hash([0; 32]),
+            sender: Address { network: "lokichain".to_string(), hash: vec![] },
+            amount: Token { value: 0, denom: "LOKI".to_string() },
+            timestamp: 0,
+            gas: 0,
+            nonce: 0,
+            data: vec![],
+            signature: Signature([0; 64])
+        };
+        let result = interactor.execute(transaction).await;
+        assert!(result.is_ok());
+    }
+}

--- a/src/application/transaction/mod.rs
+++ b/src/application/transaction/mod.rs
@@ -1,0 +1,1 @@
+mod create;

--- a/src/domain/models/token.rs
+++ b/src/domain/models/token.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Token {
-    pub amount: u64,
+    pub value: u64,
     pub denom: String
 }
 
@@ -12,7 +12,7 @@ impl PartialOrd for Token {
         if self.denom != other.denom {
             return None;
         }
-        Some(self.amount.cmp(&other.amount))
+        Some(self.value.cmp(&other.value))
     }
 }
 
@@ -21,7 +21,7 @@ impl Ord for Token {
         if self.denom != other.denom {
             panic!("Cannot compare tokens with different denominations");
         }
-        self.amount.cmp(&other.amount)
+        self.value.cmp(&other.value)
     }
 }
 
@@ -33,22 +33,22 @@ mod tests {
     #[test]
     fn test_equality() {
         let token1 = Token {
-            amount: 100,
+            value: 100,
             denom: "LOKI".to_string(),
         };
 
         let token2 = Token {
-            amount: 100,
+            value: 100,
             denom: "LOKI".to_string(),
         };
 
         let token3 = Token {
-            amount: 200,
+            value: 200,
             denom: "LOKI".to_string(),
         };
 
         let token4 = Token {
-            amount: 100,
+            value: 100,
             denom: "USDT".to_string(),
         };
 
@@ -60,17 +60,17 @@ mod tests {
     #[test]
     fn test_comparison() {
         let token1 = Token {
-            amount: 100,
+            value: 100,
             denom: "LOKI".to_string(),
         };
 
         let token2 = Token {
-            amount: 200,
+            value: 200,
             denom: "LOKI".to_string(),
         };
 
         let token3 = Token {
-            amount: 100,
+            value: 100,
             denom: "USDT".to_string(),
         };
 
@@ -86,12 +86,12 @@ mod tests {
     #[should_panic(expected = "Cannot compare tokens with different denominations")]
     fn test_ord_panic() {
         let token1 = Token {
-            amount: 100,
+            value: 100,
             denom: "LOKI".to_string(),
         };
 
         let token2 = Token {
-            amount: 200,
+            value: 200,
             denom: "USDT".to_string(),
         };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 
 mod domain;
-
+mod application;
 
 fn main() {
 


### PR DESCRIPTION
В этом дополнении
- описан прикладной слой - тут и будет основная логика. В директории `common` находятся интерфейсы к адаптерам которые будут реализованы в последнюю очередь, а в теле создал к примеру `transaction/create.rs` - пример интерактора и тест туда;
- добавлены зависимости, в частности async runtime от tokio и некоторые крейты для ошибок;
- изменен доменный тип `Token`: поле `amount`->`value`.

Стоит теперь сосредоточиться именно на прикладном слое, подумать и описать возможные юзкейсы и их логику + тесты. Только когда всё будет описано можно будет приступать к реализации адаптеров (базы данных, веб сервер и тд), а пока описывай заглушки в виде трейтов в `application/common` если потребуется реализовать в юзкейсах сохранение информации в бд