### PR TITLE
feature/app-data-domain

### DIFF
--- a/src/domain/models/app_data.rs
+++ b/src/domain/models/app_data.rs
@@ -1,5 +1,4 @@
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::fmt::Display;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 /// Message for target application

--- a/src/domain/models/app_data.rs
+++ b/src/domain/models/app_data.rs
@@ -1,0 +1,36 @@
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt::Display;
+use serde_json::Value;
+
+/// Message for target application
+///
+/// Contains application name, operation ID and payload
+///
+/// for example: `{"app":"bank","operation":"transfer","payload":{"receiver":"addr"}}`
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+pub struct AppData {
+    /// app name; ex: `bank`
+    pub app: String,
+    /// app operation; ex: `transfer`
+    pub operation: String,
+    /// app payload; ex: `{ "receiver": "addr" }`
+    pub payload: Value
+}
+
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn serialize_deserialize_app_data() {
+        let original_data = super::AppData {
+            app: "bank".to_string(),
+            operation: "transfer".to_string(),
+            payload: serde_json::json!({ "receiver": "addr" })
+        };
+
+        let serialized_data = serde_json::to_string(&original_data).unwrap();
+        let deserialized_data: super::AppData = serde_json::from_str(&serialized_data).unwrap();
+
+        assert_eq!(original_data, deserialized_data);
+    }
+}

--- a/src/domain/models/mod.rs
+++ b/src/domain/models/mod.rs
@@ -4,3 +4,4 @@ pub mod token;
 pub mod address;
 pub mod hash;
 pub mod signature;
+pub mod app_data;

--- a/src/domain/models/transaction.rs
+++ b/src/domain/models/transaction.rs
@@ -4,6 +4,7 @@ use crate::domain::models::hash::Hash;
 use crate::domain::models::signature::Signature;
 use crate::domain::models::token::Token;
 use serde::{Deserialize, Serialize};
+use crate::domain::models::app_data::AppData;
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct Transaction {
@@ -12,7 +13,7 @@ pub struct Transaction {
     /// Address of the sender
     pub sender: Address,
     /// Data field (for smart contract calls or arbitrary logic)
-    pub data: Vec<u8>,
+    pub data: AppData,
     /// Amount of tokens to transfer (if applicable)
     pub amount: Token,
     /// Timestamp of the transaction
@@ -38,7 +39,7 @@ impl Transaction {
     pub fn new(
         hash: Hash,
         sender: Address,
-        data: Vec<u8>,
+        data: AppData,
         amount: Token,
         gas: u64,
         nonce: u64,


### PR DESCRIPTION
Добавлен `AppData` тип, который представляет собой структуру содержащую сообщение о том для какого приложения предназначена транзакция, а также тип операции и инструкцию

Пример сериализованного json вида:
```json
{
  "app": "bank",
  "operation": "transfer",
  "payload": { "receiver": "some addr" }
}
```